### PR TITLE
Add POST endpoint to email API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ Open `index.html` in the root directory to use the UI.
 
 Enter an email address and see the results.
 
+### API usage
+
+You can query the service using a `POST` request as well:
+
+```
+curl -X POST http://localhost:8080/ -H "Content-Type: application/json" -d '{"email": "example@gmail.com"}'
+```
+
+
 Test with `example@gmail.com`.
 
 There's a new GitHub module. 

--- a/backend/poastal.py
+++ b/backend/poastal.py
@@ -24,9 +24,13 @@ app = Flask(__name__)
 app.config['JSON_SORT_KEYS'] = False
 CORS(app)
 
-@app.route('/')
+@app.route('/', methods=['GET', 'POST'])
 def poastal():
-    email = request.args.get('email')
+    if request.method == 'POST':
+        data = request.get_json(silent=True) or {}
+        email = data.get('email') or request.form.get('email')
+    else:
+        email = request.args.get('email')
     if email:
         twitter_result = twitter_email(email)
         snapchat_result = snapchat_email(email)
@@ -86,7 +90,7 @@ def poastal():
             }
         })
     else:
-        return 'No email address provided.'
+        return jsonify({'error': 'No email address provided.'}), 400
 
 if __name__ == '__main__':
     app.run(port=8080, debug=True)


### PR DESCRIPTION
## Summary
- support POST requests in `backend/poastal.py`
- document POST usage in README

## Testing
- `python -m py_compile backend/poastal.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f987f382c832d9c66062e849f01f1